### PR TITLE
fix: Modify sys.path in app.py to resolve ModuleNotFoundError

### DIFF
--- a/GrantMaster/app.py
+++ b/GrantMaster/app.py
@@ -1,3 +1,21 @@
+import sys
+import os
+
+# Get the directory of the currently running script (app.py)
+# In Streamlit Cloud, this will be something like /mount/src/grantmaster/GrantMaster/
+current_script_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Get the parent directory of current_script_dir
+# This should be /mount/src/grantmaster/, which is the root containing the GrantMaster package
+project_root = os.path.dirname(current_script_dir)
+
+# Add project_root to the beginning of sys.path if it's not already there
+# This allows Python to find the 'GrantMaster' package
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# --- Existing imports should now work ---
+# (The rest of the file content should follow this block)
 import streamlit as st
 import os
 from dotenv import load_dotenv


### PR DESCRIPTION
This commit addresses a `ModuleNotFoundError: No module named 'GrantMaster'` that occurred in Streamlit Cloud after converting to absolute imports.

The main change is the addition of a code block at the very beginning of `GrantMaster/app.py` that dynamically prepends the project's root directory (the directory containing the `GrantMaster` package) to `sys.path`. This ensures that Python can locate the `GrantMaster` package when `app.py` is executed, allowing the absolute imports (e.g., `from GrantMaster.core...`) to function correctly.

The existence of `GrantMaster/__init__.py` and the use of absolute imports in other project files (established in previous commits) are maintained and are prerequisites for this `sys.path` modification to be effective.