### PR TITLE
fix: Install chromium-browser to resolve "cannot find Chrome binary"

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,3 +1,8 @@
+# For Chrome/Chromium browser itself
+chromium-browser
+chromium-chromedriver
+
+# Existing libraries (keep these, they are still important)
 libglib2.0-0
 libnss3
 libgconf-2-4


### PR DESCRIPTION
This commit addresses the "unknown error: cannot find Chrome binary" issue encountered in Streamlit Cloud when running Selenium.

The primary change is updating `packages.txt` to include:
- `chromium-browser`: To install the Chromium browser executable.
- `chromium-chromedriver`: To ensure a system-level chromedriver is available, which can serve as a fallback or ensure compatibility.

The existing system libraries in `packages.txt` are preserved.

Additionally, a quick check of Selenium options in `GrantMaster/agents/researcher_agent.py` confirmed that no explicit `binary_location` is set, ensuring that chromedriver will search for the browser in the system PATH, which `apt-get install chromium-browser` should configure.