### PR TITLE
Fix: Correct packages.txt and update Chrome binary path

### DIFF
--- a/GrantMaster/agents/researcher_agent.py
+++ b/GrantMaster/agents/researcher_agent.py
@@ -57,7 +57,7 @@ def perform_website_login(url, username, password, timeout=10):
         # chrome_options.add_argument("--enable-logging=stderr --v=1") # More detailed chrome logging
 
         # Forcing the browser binary location
-        expected_browser_path = "/usr/bin/chromium-browser"
+        expected_browser_path = "/usr/bin/chromium"
         print(f"Attempting to set browser binary location to: {expected_browser_path}")
         chrome_options.binary_location = expected_browser_path
 

--- a/packages.txt
+++ b/packages.txt
@@ -1,18 +1,15 @@
-# For Chrome/Chromium browser itself
-chromium-browser
-chromium-chromedriver
-
-# Existing libraries (keep these, they are still important)
-libglib2.0-0
-libnss3
-libgconf-2-4
+chromium
+chromium-driver
+libasound2
 libfontconfig1
+libgbm1
+libgconf-2-4
+libglib2.0-0
+libgtk-3-0
+libnss3
 libx11-6
 libx11-xcb1
 libxcomposite1
 libxdamage1
 libxrandr2
-libgbm1
-libgtk-3-0
-libasound2
 libxtst6


### PR DESCRIPTION
This commit addresses errors in `packages.txt` that caused apt-get failures and ensures the correct Chrome binary path is used.

Changes:
1.  `packages.txt`:
    *   Removed all comment lines and non-package descriptive text.
    *   Replaced `chromium-browser` with `chromium`.
    *   Replaced `chromium-chromedriver` with `chromium-driver`.
    *   Ensured all other essential libraries are correctly listed.
2.  `GrantMaster/agents/researcher_agent.py`:
    *   Updated `chrome_options.binary_location` from `"/usr/bin/chromium-browser"` to `"/usr/bin/chromium"` to align with the package name change.

These corrections should resolve the `apt-get` installation issues and allow chromedriver to correctly locate the Chromium browser.