### PR TITLE
Feat: Implement API key management and enhance research logging

### DIFF
--- a/GrantMaster/agents/analyst_agent.py
+++ b/GrantMaster/agents/analyst_agent.py
@@ -7,10 +7,11 @@ from GrantMaster.core.data_manager import DataManager
 # AnalystAgent class is defined in the same file, so direct use is fine.
 
 class AnalystAgent:
-    def __init__(self, openai_client, model="gpt-3.5-turbo"):
-        self.openai_client = openai_client
-        self.model = model
-        print(f"AnalystAgent initialized with model: {self.model}")
+    def __init__(self, api_key: str, model_name="gpt-3.5-turbo"): # Modified signature
+        self.api_key = api_key # Store api_key if needed for other methods, or use directly
+        self.openai_client = OpenAI(api_key=self.api_key) # Initialize client
+        self.model_name = model_name # Using model_name for consistency with prompt
+        print(f"AnalystAgent initialized with model: {self.model_name}")
 
     def analyze_suitability(self, grant_info_dict, org_profile_dict):
         print(f"AnalystAgent: Analyzing suitability for grant '{grant_info_dict.get('grant_title', 'N/A')}'...")
@@ -65,12 +66,12 @@ class AnalystAgent:
             # response_format_param = {{ "type": "json_object" }}
             # For older models, rely on prompt engineering for JSON.
             response_format_param = None 
-            if "1106" in self.model or "gpt-4" in self.model: # Basic check if model might support json_object mode
+            if "1106" in self.model_name or "gpt-4" in self.model_name: # Basic check if model might support json_object mode, using self.model_name
                  response_format_param = {{ "type": "json_object" }}
 
 
             completion_args = {{
-                "model": self.model,
+                "model": self.model_name, # Using self.model_name
                 "messages": [
                     {{"role": "system", "content": "You are an expert AI that analyzes grant suitability and returns analysis in a specific JSON format."}},
                     {{"role": "user", "content": prompt}}

--- a/GrantMaster/agents/editor_agent.py
+++ b/GrantMaster/agents/editor_agent.py
@@ -5,10 +5,11 @@ from GrantMaster.core.graph_state import GrantMasterState
 # EditorAgent class is defined in the same file.
 
 class EditorAgent:
-    def __init__(self, openai_client, model="gpt-4o"): # Using a capable model for review
-        self.openai_client = openai_client
-        self.model = model
-        print(f"EditorAgent initialized with model: {self.model}")
+    def __init__(self, api_key: str, model_name="gpt-4o"): # Modified signature, kept gpt-4o
+        self.api_key = api_key # Store api_key if needed
+        self.openai_client = OpenAI(api_key=self.api_key) # Initialize client
+        self.model_name = model_name # Using model_name for consistency
+        print(f"EditorAgent initialized with model: {self.model_name}")
 
     def review_draft(self, draft_text, section_name, grant_guidelines_summary=''):
         print(f"EditorAgent: Reviewing draft for section '{section_name}'...")
@@ -50,7 +51,7 @@ class EditorAgent:
         print(f"EditorAgent: Sending request to OpenAI API for review of section '{section_name}'.")
         try:
             completion = self.openai_client.chat.completions.create(
-                model=self.model,
+                model=self.model_name, # Using self.model_name
                 messages=[
                     {"role": "system", "content": "You are an expert AI grant editor. Your task is to provide critical and actionable feedback on a grant section draft based on provided criteria. Do not rewrite the draft; only provide feedback points or a summarized critique."},
                     {"role": "user", "content": prompt}

--- a/GrantMaster/agents/writer_agent.py
+++ b/GrantMaster/agents/writer_agent.py
@@ -5,10 +5,11 @@ from GrantMaster.core.graph_state import GrantMasterState
 # WriterAgent class is defined in the same file.
 
 class WriterAgent:
-    def __init__(self, openai_client, model="gpt-4o"): # Defaulting to a more advanced model
-        self.openai_client = openai_client
-        self.model = model
-        print(f"WriterAgent initialized with model: {self.model}")
+    def __init__(self, api_key: str, model_name="gpt-4o"): # Modified signature, kept gpt-4o as it was specific
+        self.api_key = api_key # Store api_key if needed
+        self.openai_client = OpenAI(api_key=self.api_key) # Initialize client
+        self.model_name = model_name # Using model_name for consistency
+        print(f"WriterAgent initialized with model: {self.model_name}")
 
     def draft_section(self, grant_opportunity_details, org_profile, section_name, specific_instructions=''):
         print(f"WriterAgent: Drafting section '{section_name}' for grant '{grant_opportunity_details.get('grant_title', 'N/A')}'...")
@@ -47,7 +48,7 @@ class WriterAgent:
         print(f"WriterAgent: Sending request to OpenAI API for section '{section_name}'.")
         try:
             completion = self.openai_client.chat.completions.create(
-                model=self.model,
+                model=self.model_name, # Using self.model_name
                 messages=[
                     {"role": "system", "content": "You are an expert AI grant writer. Your task is to draft high-quality content for specific grant proposal sections based on provided context and instructions. Output only the drafted text."},
                     {"role": "user", "content": prompt}

--- a/GrantMaster/core/graph_orchestrator.py
+++ b/GrantMaster/core/graph_orchestrator.py
@@ -19,24 +19,33 @@ from GrantMaster.agents.editor_agent import EditorAgent, node_review_draft
 # print("Attempted to load .env file for GraphOrchestrator (if present)")
 
 class GraphOrchestrator:
-    def __init__(self):
-        # Initialize OpenAI client
-        # It's good practice to ensure the API key is actually found.
-        openai_api_key = os.getenv("OPENAI_API_KEY")
-        if not openai_api_key:
-            print("WARNING: OPENAI_API_KEY environment variable not found. OpenAI dependent agents may fail.")
-            # Depending on strictness, could raise an error:
-            # raise ValueError("OPENAI_API_KEY not found. Please set the environment variable.")
-        self.openai_client = OpenAI(api_key=openai_api_key)
+    def __init__(self, api_key: str): # Modified signature
+        self.api_key = api_key # Store api_key
+
+        # Initialize OpenAI client with the passed api_key
+        # This client might still be useful if some components expect a client instance
+        # rather than an API key directly, or for direct calls if needed.
+        self.openai_client = OpenAI(api_key=self.api_key)
 
         # Initialize DataManager
         self.data_manager = DataManager() # Assumes db_name is default or handled by DataManager
 
-        # Initialize Agents
-        self.research_agent = WebSleuthAgent(openai_client=self.openai_client)
-        self.analyst_agent = AnalystAgent(openai_client=self.openai_client)
-        self.writer_agent = WriterAgent(openai_client=self.openai_client)
-        self.editor_agent = EditorAgent(openai_client=self.openai_client)
+        # Define model names (these could be made configurable or passed in later)
+        # Using default values as an example, consistent with some agent defaults.
+        research_model_name = "gpt-3.5-turbo" 
+        analyst_model_name = "gpt-3.5-turbo"
+        writer_model_name = "gpt-3.5-turbo"
+        editor_model_name = "gpt-3.5-turbo"
+
+        # Initialize Agents - passing api_key directly as per subtask instructions.
+        # This assumes Agent constructors will be updated to accept api_key directly.
+        # The variable `self.research_agent` was previously used for WebSleuthAgent.
+        self.research_agent = WebSleuthAgent(api_key=self.api_key, model=research_model_name)
+        self.analyst_agent = AnalystAgent(api_key=self.api_key, model_name=analyst_model_name)
+        self.writer_agent = WriterAgent(api_key=self.api_key, model_name=writer_model_name)
+        self.editor_agent = EditorAgent(api_key=self.api_key, model_name=editor_model_name)
+        # Note: The prompt did not require changing ResearcherAgent if it exists and differs from WebSleuthAgent.
+        # The current code only has self.research_agent assigned to WebSleuthAgent.
         print("GraphOrchestrator: All agents and DataManager initialized.")
 
         # Create StateGraph


### PR DESCRIPTION
This commit introduces robust API key management and significantly improves logging for my research operations.

Key Changes:

Part 1: API Key Management
- `GrantMaster/app.py`:
    - Added a sidebar text input for you to provide your OpenAI API Key, stored in `st.session_state`.
    - Implemented logic to resolve the API key by checking (in order):
        1. Your input from `st.session_state`.
        2. Streamlit Secrets (`st.secrets["OPENAI_API_KEY"]`). 3. Environment variable (`os.environ.get("OPENAI_API_KEY")`).
    - The application will show an error and stop if no key is found.
    - `GraphOrchestrator` is now initialized with the resolved API key.
- `GrantMaster/core/graph_orchestrator.py`:
    - `GraphOrchestrator.__init__` now accepts an `api_key: str`.
    - This key is used to initialize its own `OpenAI` client and is passed to my internal components.
- `GrantMaster/agents/*.py` (WebSleuthAgent, AnalystAgent, WriterAgent, EditorAgent):
    - Modified `__init__` methods to accept `api_key: str`.
    - Each internal component now initializes its own `OpenAI` client using this key.

Part 2: Enhancing Post-Login Logging & Initial Research Strategy
- `GrantMaster/agents/researcher_agent.py`:
    - In `node_research_and_extract`: - Added logging for the current URL, page title, and a snippet of the page source after successful login to provide context on the landing page. These logs are added to `state['log_messages']`.
    - In `WebSleuthAgent.research_and_extract`:
        - Refactored to collect internal logs into a list.
        - Added detailed logging for LLM interactions:
            - Summary of the prompt being sent.
            - Snippet of the raw LLM response. - Errors during LLM response parsing. - This method now returns `(extracted_grants, internal_logs)`.
    - `node_research_and_extract` was updated to receive these internal logs from `WebSleuthAgent` and append them to the main `log_messages` list, making them available in the downloadable log file.